### PR TITLE
chore: remove footnote tagline

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,6 @@
         <button data-view="inbox">Inbox (Approvals)</button>
         <button data-view="audit">Audit & Export</button>
       </nav>
-      <div class="footnote">vNEXT • Static SPA • Cloudflare‑ready</div>
     </aside>
 
     <main>


### PR DESCRIPTION
## Summary
- remove sidebar footnote tagline from index

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68b9b90df5208330a104c8d35713dd4c